### PR TITLE
Allow for Collectors Edition maps (CE Maps)

### DIFF
--- a/Collect.lua
+++ b/Collect.lua
@@ -21,6 +21,7 @@ function SurveyZoneList.Collect:search()
     self.orderedList = {}
 
     local bagItems = GetBagSize(BAG_BACKPACK)
+	itemName = string.gsub(itemName, " ce ", " ")
     local itemZoneName = ""
 
     for slotIdx=0, bagItems, 1 do


### PR DESCRIPTION
Hi,

This fixes an issue where the collectors edition maps were seen as new regions with ce at the end of it - e.g. `glenumbra ce`

Hope this helps.

